### PR TITLE
chore: updating types declaration after first execution

### DIFF
--- a/packages/client/next-env.d.ts
+++ b/packages/client/next-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/types/global" />
-/// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/packages/restaurant/next-env.d.ts
+++ b/packages/restaurant/next-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/types/global" />
-/// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/basic-features/typescript for more information.


### PR DESCRIPTION
when i ran for the first time it automatically removed this line:
`/// <reference types="next/image-types/global" />`